### PR TITLE
argon2 support for browser

### DIFF
--- a/examples/example-password-argon2.js
+++ b/examples/example-password-argon2.js
@@ -1,0 +1,33 @@
+let dataparty_crypto = require('../dist/dataparty-crypto.js')
+
+async function main (){
+
+    const password = 'super-strong-password'
+    const salt = await dataparty_crypto.Routines.generateSalt()
+    //const salt = Buffer.from('60312b38547ee7141c0f3d79df97663a1e746313e3c3c3d414436b1fc78552d9', 'hex') //! Salt would be read from disk after 1st run
+
+    console.log('salt')
+    console.log('\t', salt.toString('hex'))
+
+
+    let startMs = Date.now()
+
+
+    let key = await dataparty_crypto.Routines.createKeyFromPasswordArgon2(password, salt)
+
+    let endMs = Date.now()
+
+
+    console.log('key')
+    console.log(key)
+
+
+    const deltaMs = endMs - startMs
+
+    console.log('time (ms):', (deltaMs/1000) )
+}
+
+main().catch(err=>{
+    console.log('ERROR - we crashed')
+    console.log(err)
+})

--- a/examples/example-password-argon2.js
+++ b/examples/example-password-argon2.js
@@ -1,10 +1,11 @@
+const argon2 = require('argon2')
 let dataparty_crypto = require('../dist/dataparty-crypto.js')
 
 async function main (){
 
     const password = 'super-strong-password'
-    const salt = await dataparty_crypto.Routines.generateSalt()
-    //const salt = Buffer.from('60312b38547ee7141c0f3d79df97663a1e746313e3c3c3d414436b1fc78552d9', 'hex') //! Salt would be read from disk after 1st run
+    //const salt = await dataparty_crypto.Routines.generateSalt()
+    const salt = Buffer.from('26bd99303dee4ee53342e89bd9f01a80c1fecf0d6b0c6c8eefee5a1eeeb8a0ec', 'hex') //! Salt would be read from disk after 1st run
 
     console.log('salt')
     console.log('\t', salt.toString('hex'))
@@ -13,7 +14,11 @@ async function main (){
     let startMs = Date.now()
 
 
-    let key = await dataparty_crypto.Routines.createKeyFromPasswordArgon2(password, salt)
+    const key = await dataparty_crypto.Routines.createKeyFromPasswordArgon2(
+        argon2,
+        "supersecretpassword123",
+        salt
+    )
 
     let endMs = Date.now()
 

--- a/examples/example-password-pbkdf2.js
+++ b/examples/example-password-pbkdf2.js
@@ -13,7 +13,7 @@ async function main (){
     let startMs = Date.now()
 
 
-    let key = await dataparty_crypto.Routines.createKeyFromPassword(password, salt)
+    let key = await dataparty_crypto.Routines.createKeyFromPasswordPbkdf2(password, salt)
 
     let endMs = Date.now()
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -99,9 +99,18 @@ async function argonTest(){
 
     console.log('Argon Test')
 
-    const salt = await dataparty_crypto.Routines.generateSalt()
+    const fromHexString = (hexString) =>
+  Uint8Array.from(hexString.match(/.{1,2}/g).map((byte) => parseInt(byte, 16)));
 
-    console.log('\t','salt', salt)
+
+    //const salt = await dataparty_crypto.Routines.generateSalt()
+
+   
+    const salt = fromHexString('26bd99303dee4ee53342e89bd9f01a80c1fecf0d6b0c6c8eefee5a1eeeb8a0ec')
+
+
+    console.log('\t','salt', salt.toString('hex'))
+    console.log(salt)
 
     console.log(argon2)
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,6 +1,8 @@
 <html>
     <head>
         <script src="libs/dataparty-crypto-browser.js"></script>
+
+        <script src="node_modules/argon2-browser/lib/argon2.js"></script>
     </head>
     <body>
 
@@ -93,9 +95,33 @@ async function main (){
     await signedMsgCopy.assertVerified(aliceCopy)
 }
 
+async function argonTest(){
+
+    console.log('Argon Test')
+
+    const salt = await dataparty_crypto.Routines.generateSalt()
+
+    console.log('\t','salt', salt)
+
+    console.log(argon2)
+
+    const key = await dataparty_crypto.Routines.createKeyFromPasswordArgon2(
+        argon2,
+        "supersecretpassword123",
+        salt
+    )
+
+    console.log(key)
+
+}
+
 main().catch(err=>{
     console.log('ERROR - we crashed')
     console.log(err)
+})
+.finally(()=>{
+    
+    return argonTest()
 })
 
         </script>

--- a/examples/node_modules
+++ b/examples/node_modules
@@ -1,0 +1,1 @@
+../node_modules/

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "@parcel/transformer-typescript-types": "^2.7.0",
     "@types/faker": "^4.1.5",
     "@types/jest": "^24.0.15",
+    "argon2": "^0.30.3",
+    "argon2-browser": "^1.18.0",
     "events": "^3.3.0",
     "faker": "^4.1.0",
     "jest": "^24.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dataparty/crypto",
   "private": false,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "dataparty crypto routines",
   "main": "./dist/dataparty-crypto.js",
   "frontend": "dist/dataparty-crypto-browser.js",

--- a/src/routines.ts
+++ b/src/routines.ts
@@ -176,7 +176,7 @@ export const createKeyFromPasswordArgon2 = async (
   argon: any,
   password: string,
   salt: Uint8Array,
-  associatedData: Buffer,
+  //associatedData: Buffer,
   timeCost: Number = 3,
   memoryCost: Number = 65536,
   parallelism: Number = 4,
@@ -200,7 +200,7 @@ export const createKeyFromPasswordArgon2 = async (
     const hashResult = await argon.hash({
       pass: password,
       salt,
-      ad: associatedData,
+      //ad: associatedData,
       time: timeCost,
       mem: memoryCost,
       parallelism,
@@ -215,6 +215,28 @@ export const createKeyFromPasswordArgon2 = async (
   } else {
 
     //! node
+    let argonType = {
+      'argon2d': argon.argon2d,
+      'argon2i': argon.argon2i,
+      'argon2id': argon.argon2id
+    }[type]
+
+    const hashResult = await argon.hash(password, {
+      salt,
+      //associatedData,
+      timeCost,
+      memoryCost,
+      parallelism,
+      hashLength,
+      type: argonType,
+      raw: true
+    })
+
+    console.log('hashResult', hashResult)
+
+  
+    fullSecret = hashResult
+
 
   }
 

--- a/src/routines.ts
+++ b/src/routines.ts
@@ -122,9 +122,9 @@ export const generateSalt = async (): Buffer => {
 }
 
 /**
- * Generate private and public keys from password and salt
+ * Generate private and public keys from password and salt using pbkdf2
  */
-export const createKeyFromPassword = async (
+export const createKeyFromPasswordPbkdf2 = async (
   password: string,
   salt: Buffer,
   rounds: Number = 500000
@@ -157,6 +157,87 @@ export const createKeyFromPassword = async (
     },
     type: "nacl"
   };
+
+};
+
+/**
+ * Generate private key from password using argon2
+ * @param argon 
+ * @param password 
+ * @param salt 
+ * @param associatedData 
+ * @param timeCost 
+ * @param memoryCost 
+ * @param parallelism 
+ * @param type 
+ * @param hashLength 
+ */
+export const createKeyFromPasswordArgon2 = async (
+  argon: any,
+  password: string,
+  salt: Uint8Array,
+  associatedData: Buffer,
+  timeCost: Number = 3,
+  memoryCost: Number = 65536,
+  parallelism: Number = 4,
+  type: string = 'argon2id',
+  hashLength: Number = 64
+): IKey => {
+
+  let fullSecret = null
+
+  console.log('createKeyFromPasswordArgon2')
+
+  if( typeof argon.unloadRuntime == 'function' ){
+
+    //! brower
+    let argonType = {
+      'argon2d': argon.ArgonType.Argon2d,
+      'argon2i': argon.ArgonType.Argon2i,
+      'argon2id': argon.ArgonType.Argon2id
+    }[type]
+
+    const hashResult = await argon.hash({
+      pass: password,
+      salt,
+      ad: associatedData,
+      time: timeCost,
+      mem: memoryCost,
+      parallelism,
+      hashLen: hashLength,
+      type: argonType
+    })
+
+    console.log('hashResult', hashResult)
+
+    fullSecret = hashResult.hash
+  
+  } else {
+
+    //! node
+
+  }
+
+
+
+  const boxSecret = fullSecret.slice(0, 32)
+  const signSeed = fullSecret.slice(32)
+
+  const boxKeyPair = box.keyPair.fromSecretKey(boxSecret);
+  const signKeyPair = sign.keyPair.fromSeed(signSeed);
+
+  return {
+    private: {
+      box: base64.encode(boxKeyPair.secretKey),
+      sign: base64.encode(signKeyPair.secretKey)
+    },
+    public: {
+      box: base64.encode(boxKeyPair.publicKey),
+      sign: base64.encode(signKeyPair.publicKey)
+    },
+    type: "nacl"
+  };
+
 
 };
 

--- a/src/routines.ts
+++ b/src/routines.ts
@@ -161,16 +161,16 @@ export const createKeyFromPasswordPbkdf2 = async (
 };
 
 /**
- * Generate private key from password using argon2
- * @param argon 
+ * Generate private key from password using argon2. You must pass in the instance
+ * of argon2. We expect either `npm:argon2` or `npm:argon2-browser`.
+ * @param argon Instance of argon2 either from `npm:argon2` or `npm:argon2-browser`
  * @param password 
  * @param salt 
- * @param associatedData 
- * @param timeCost 
- * @param memoryCost 
- * @param parallelism 
- * @param type 
- * @param hashLength 
+ * @param timeCost      Defaults to 3
+ * @param memoryCost    Defaults to 64MB
+ * @param parallelism   Defaults to 4
+ * @param type          Defaults to `argon2id`
+ * @param hashLength    Defaults to 64
  */
 export const createKeyFromPasswordArgon2 = async (
   argon: any,
@@ -185,8 +185,6 @@ export const createKeyFromPasswordArgon2 = async (
 ): IKey => {
 
   let fullSecret = null
-
-  console.log('createKeyFromPasswordArgon2')
 
   if( typeof argon.unloadRuntime == 'function' ){
 
@@ -207,8 +205,6 @@ export const createKeyFromPasswordArgon2 = async (
       hashLen: hashLength,
       type: argonType
     })
-
-    console.log('hashResult', hashResult)
 
     fullSecret = hashResult.hash
   
@@ -231,15 +227,11 @@ export const createKeyFromPasswordArgon2 = async (
       type: argonType,
       raw: true
     })
-
-    console.log('hashResult', hashResult)
-
   
     fullSecret = hashResult
 
 
   }
-
 
 
   const boxSecret = fullSecret.slice(0, 32)


### PR DESCRIPTION
## Issues resolved:

- [x] closes #15


## Screenshot (optional)

Stable generation of key in both browser and node.

![Screenshot_2023-04-22_05-02-43](https://user-images.githubusercontent.com/662932/233783812-a2ec807c-2ee4-447b-b7b7-dae6ccfc2339.png)
![Screenshot_2023-04-22_05-03-03](https://user-images.githubusercontent.com/662932/233783821-be21d4ef-2c66-45e7-bf57-77bfb41b96d0.png)


### Examples

Added new examples:

 * nodejs - `examples/example-password-argon2.js`
 * browser - `examples/index.html` see `argonTest()`
