### PR TITLE
fix: correct pqSignSLDSeed to pqSignSLHSeed in routines.ts

### DIFF
--- a/src/routines.ts
+++ b/src/routines.ts
@@ -179,12 +179,12 @@ export const createKey = async (
 
     const pqKemSeed = await hkdf('sha512', seed, HkdfFullseedSalt, 'pqkem', pqkemClass.lengths.seed)
     const pqSignMLSeed = await hkdf('sha512', seed, HkdfFullseedSalt, 'pqsignml', pqsignmlClass.lengths.seed)
-    const pqSignSLDSeed = await hkdf('sha512', seed, HkdfFullseedSalt, 'pqsignslh', pqsignslhClass.lengths.seed)
+    const pqSignSLHSeed = await hkdf('sha512', seed, HkdfFullseedSalt, 'pqsignslh', pqsignslhClass.lengths.seed)
   
   
     const pqKemKeyPair = pqkemClass.keygen( pqKemSeed );
     const pqSignMLKeyPair = pqsignmlClass.keygen( pqSignMLSeed );
-    const pqSignSLHKeyPair = pqsignslhClass.keygen( pqSignSLDSeed );
+    const pqSignSLHKeyPair = pqsignslhClass.keygen( pqSignSLHSeed );
     
     const keyHash = hash(
       Buffer.concat([


### PR DESCRIPTION
## Fix

Correct `pqSignSLDSeed` → `pqSignSLHSeed` in src/routines.ts (lines 182, 187) to match the class name `pqsignslhClass` and key pair variable `pqSignSLHKeyPair`.

Fixes #50